### PR TITLE
Only grant (or revoke) admin option in group:members:add if requested.

### DIFF
--- a/lib/conjur/command/groups.rb
+++ b/lib/conjur/command/groups.rb
@@ -20,17 +20,31 @@ class Conjur::Command::Groups < Conjur::Command
   desc "Add a new group member"
   arg_name "group member"
   command :"members:add" do |c|
-    c.desc "Grant with admin option"
+    c.desc "Also grant the admin option"
     c.switch [:a, :admin]
+
+    # perhaps this belongs to member:remove, but then either
+    # it would be possible to grant membership with member:revoke,
+    # or we would need two round-trips to authz
+    c.desc "Revoke the grant option if it's granted"
+    c.switch [:r, :'revoke-admin']
     
     c.action do |global_options,options,args|
       group = require_arg(args, 'group')
       member = require_arg(args, 'member')
       
       group = api.group(group)
-      api.role(group.roleid).grant_to member, !!options[:admin]
-
-      puts "Membership granted"
+      opts = nil
+      message = "Membership granted"
+      if options[:admin] then
+        opts = { admin_option: true }
+        message = "Adminship granted"
+      elsif options[:'revoke-admin'] then
+        opts = { admin_option: false }
+        message = "Adminship revoked"
+      end
+      api.role(group.roleid).grant_to member, opts
+      puts message
     end
   end
 

--- a/spec/command/groups_spec.rb
+++ b/spec/command/groups_spec.rb
@@ -1,0 +1,39 @@
+require 'spec_helper'
+
+describe Conjur::Command::Groups, logged_in: true do
+  describe_command "group:members:add group role" do
+    it "adds the role to the group" do
+           RestClient::Request.should_receive(:execute).with(
+        method: :put,
+        url: "https://authz.example.com/the-account/roles/group/group/?members&member=role",
+        headers: {},
+        payload: nil
+      )
+      invoke
+    end
+  end
+
+  describe_command "group:members:add -a group role" do
+    it "adds the role to the group with admin option" do
+           RestClient::Request.should_receive(:execute).with(
+        method: :put,
+        url: "https://authz.example.com/the-account/roles/group/group/?members&member=role",
+        headers: {},
+        payload: { admin_option: true }
+      )
+      invoke
+    end
+  end
+
+  describe_command "group:members:add -r group role" do
+    it "revokes the admin rights" do
+           RestClient::Request.should_receive(:execute).with(
+        method: :put,
+        url: "https://authz.example.com/the-account/roles/group/group/?members&member=role",
+        headers: {},
+        payload: { admin_option: false }
+      )
+      invoke
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -47,8 +47,9 @@ shared_context "when logged in", logged_in: true do
   include_context "with mock authn"
   let(:username) { 'dknuth' }
   let(:api_key) { 'sekrit' }
-  let(:api) { Conjur::API.new_from_token({ 'data' => username }) }
+  let(:api) { Conjur::API.new_from_key(username, api_key) }
   before do
+    api.stub credentials: {}
     netrc[authn_host] = [username, api_key]
     Conjur::Command.stub api: api
   end


### PR DESCRIPTION
Fixes BC#49083893-high-unable-to-add-a
