### PR TITLE
Make "kind" and "mime-type" parameters optional in variable:create

### DIFF
--- a/lib/conjur/command/variables.rb
+++ b/lib/conjur/command/variables.rb
@@ -28,10 +28,10 @@ class Conjur::Command::Variables < Conjur::Command
   arg_name "id?"
   command :create do |c|
     c.arg_name "mime_type"
-    c.flag [:m, :"mime-type"]
+    c.flag [:m, :"mime-type"], default_value: "text/plain"
     
     c.arg_name "kind"
-    c.flag [:k, :"kind"]
+    c.flag [:k, :"kind"], default_value: "secret"
     
     acting_as_option(c)
     
@@ -44,7 +44,7 @@ class Conjur::Command::Variables < Conjur::Command
       
       options.delete(:"mime-type")
       options.delete(:"kind")
-      
+    
       var = api.create_variable(mime_type, kind, options)
       display(var, options)
     end

--- a/spec/command/variables_spec.rb
+++ b/spec/command/variables_spec.rb
@@ -3,9 +3,9 @@ require 'spec_helper'
 describe Conjur::Command::Variables, logged_in: true do
   let(:collection_url) { "https://core.example.com/variables" }
 
-  let(:base_payload) { { mime_type: 'text/plain', kind: 'password' } }
+  let(:base_payload) { { mime_type: 'text/json', kind: 'password' } }
 
-  describe_command "variable:create -m text/plain -k password" do
+  describe_command "variable:create -m text/json -k password" do
     it "lets the server assign the id" do
      RestClient::Request.should_receive(:execute).with(
         method: :post,
@@ -17,7 +17,7 @@ describe Conjur::Command::Variables, logged_in: true do
       expect { invoke }.to write({ id: 'assigned-id' }).to(:stdout)
     end
   end
-  describe_command "variable:create -m text/plain -k password the-id" do
+  describe_command "variable:create -m text/json -k password the-id" do
     it "propagates the user-assigned id" do
      RestClient::Request.should_receive(:execute).with(
         method: :post,
@@ -29,4 +29,20 @@ describe Conjur::Command::Variables, logged_in: true do
       expect { invoke }.to write({ id: 'the-id' }).to(:stdout)
     end
   end
+
+
+  describe_command "variable:create" do
+    it "provides default values for optional parameters mime_type and kind" do
+      RestClient::Request.should_receive(:execute).with(
+        method: :post,
+        url: collection_url,
+        headers: {},
+        payload: { mime_type: 'text/plain', kind: 'secret'}
+        ).and_return(post_response('the-id'))
+      expect { invoke }.to write # invoke_silently
+    end
+  end
+
+
+
 end


### PR DESCRIPTION
Fixes BC#69300263-normal-migrate
