### PR TITLE
Modify kind naming for the specific commands

### DIFF
--- a/lib/conjur/command/authn.rb
+++ b/lib/conjur/command/authn.rb
@@ -45,6 +45,8 @@ DESC
     c.flag [:"cas-server"]
     
     c.action do |global_options,options,args|
+      options[:u] = remove_kind_from_id(options[:u], 'user') unless options[:u].nil?
+      options[:username] = remove_kind_from_id(options[:username], 'user') unless options[:u].nil?
       Conjur::Authn.login(options)
     end
   end

--- a/lib/conjur/command/groups.rb
+++ b/lib/conjur/command/groups.rb
@@ -52,6 +52,8 @@ class Conjur::Command::Groups < Conjur::Command
     c.action do |global_options,options,args|
       group = require_arg(args, 'group')
       member = require_arg(args, 'member')
+      member = add_kind_to_id member, 'user'
+      group = add_kind_to_id group, 'group'
       
       group = api.group(group)
       opts = nil

--- a/lib/conjur/command/users.rb
+++ b/lib/conjur/command/users.rb
@@ -48,7 +48,8 @@ class Conjur::Command::Users < Conjur::Command
     
     c.action do |global_options,options,args|
       login = require_arg(args, 'login')
-      
+      login = remove_kind_from_id login, 'user'
+
       opts = options.slice(:ownerid)
 
       if options[:p]
@@ -72,3 +73,4 @@ class Conjur::Command::Users < Conjur::Command
     end
   end
 end
+

--- a/lib/conjur/identifier_manipulation.rb
+++ b/lib/conjur/identifier_manipulation.rb
@@ -22,6 +22,28 @@ module Conjur
       [kind, tokens.join(':')]
     end
 
+    # removes kind for specific commands
+    def remove_kind_from_id id, kindname
+      tokens = id.split ':' unless id.nil?
+      raise "At largest 2 tokens expected in #{id}" if tokens.size > 2
+      if tokens.size == 2
+        raise "Expecting kind name is only #{kindname}" unless tokens[0] == kindname
+        id = tokens[1]
+      else
+        id = tokens.shift
+      end
+      id
+    end
+
+    # adds kind for specific commands
+    def add_kind_to_id id, kindname
+      tokens = id.split ':' unless id.nil?
+      if tokens.count == 1
+        id = [kindname, tokens].join(':')
+      end
+      id
+    end
+
     def conjur_account
       Conjur::Core::API.conjur_account
     end


### PR DESCRIPTION
I have modified the kind naming for the specific commands such as user:create, authn:login.
Kind naming means that assets specific commands like user: will tolerate presence of prefix 'user' in front of the resource id of failing with error.
For example,
     conjur user:create $ns-alice      =      conjur user:create user:$ns-alice
