### PR TITLE
user:deprovision

### DIFF
--- a/lib/conjur/command/users.rb
+++ b/lib/conjur/command/users.rb
@@ -89,4 +89,13 @@ class Conjur::Command::Users < Conjur::Command
       Conjur::API.update_password username, password, new_password
     end
   end
+
+  desc "Revoke all roles from the user" 
+  arg_name "username"
+  command :deprovision do |c|
+    c.action do |global_options,options,args|
+      id = "user:"+require_arg(args, 'id')
+      api.role(id).all.each { |r|  r.revoke_from id }
+    end
+  end
 end

--- a/spec/command/users_spec.rb
+++ b/spec/command/users_spec.rb
@@ -29,4 +29,21 @@ describe Conjur::Command::Users, logged_in: true do
       end
     end
   end
+
+
+  context "Deprovisioning" do
+    let(:userid) { "badguy" }
+    let(:roles_list) { ["user:badguy", "group:goodguys"].map {|r| double(roleid: r)  } }
+    let(:user_role) { double(all: roles_list) }
+
+    describe_command "user:deprovision badguy" do
+      it 'revokes all roles from user' do
+        api.should_receive(:role).with("user:"+userid).and_return(user_role)
+        roles_list.each { |role|  
+          role.should_receive(:revoke_from).with("user:"+userid)
+        }
+        invoke
+      end
+    end
+  end
 end


### PR DESCRIPTION
naive implementation, although hopefully workable (did not tested yet against live database, but will do in minutes)

usage against own account (or from not fully privileged account) may result to unexpected (but predictable) results like roles partially revoked, etc.

Eventually I'd say we need batch (transactional) method in the REST API for doing this.

Also there's open question what to do with role which has no more memberships. And also whether we need to revoke it's role itself from all members.
