### PR TITLE
Store appliance URL in runner context

### DIFF
--- a/lib/conjur/dsl/runner.rb
+++ b/lib/conjur/dsl/runner.rb
@@ -12,11 +12,14 @@ module Conjur
       
       def initialize(script, filename = nil)
         @context = {
-          "env" => Conjur.env,
-          "stack" => Conjur.stack,
           "account" => Conjur.account,
           "api_keys" => {}
         }
+
+        @context['env'] = Conjur.env unless Conjur.env == 'production'
+        @context['stack'] = Conjur.stack unless Conjur.stack == 'v4'
+        @context['appliance_url'] = Conjur.configuration.appliance_url unless Conjur.configuration.appliance_url.nil?
+
         @script = script
         @filename = filename
         @api = nil

--- a/spec/dsl/runner_spec.rb
+++ b/spec/dsl/runner_spec.rb
@@ -31,4 +31,35 @@ describe Conjur::DSL::Runner, logged_in: true do
       "the-account:user:alice" => "the-api-key"
     }
   end
+
+  it "doesn't store default env and stack in context" do
+    expect(runner.context).to_not have_key 'env'
+    expect(runner.context).to_not have_key 'stack'
+  end
+
+  context "with non-default stack and env" do
+    let(:runner) do
+      Conjur::Config.merge env: 'baz', stack: 'bar'
+      Conjur::Config.apply
+      Conjur::DSL::Runner.new '', nil
+    end
+
+    it "stores ther in context" do
+      expect(runner.context['env']).to eq 'baz'
+      expect(runner.context['stack']).to eq 'bar'
+    end
+  end
+
+  context "with appliance url" do
+    let(:appliance_url) { "https://conjur.example.com/api" }
+    let(:runner) do
+      Conjur::Config.merge appliance_url: appliance_url
+      Conjur::Config.apply
+      Conjur::DSL::Runner.new '', nil
+    end
+
+    it "stores appliance url in the context" do
+      expect(runner.context['appliance_url']).to eq appliance_url
+    end
+  end
 end


### PR DESCRIPTION
We've discussed this change today. 
I also omit stack/env unless they're not default.
