### PR TITLE
Decide to publish based on git tag

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -37,32 +37,36 @@ pipeline {
       }
     }
 
-    // Only publish to RubyGems if branch is 'master'
-    // AND someone confirms this stage within 5 minutes
-    stage('Publish to RubyGems?') {
+    // Only publish to RubyGems if the HEAD is
+    // tagged with the same version as in version.rb
+    stage('Publish to RubyGems') {
       agent { label 'releaser-v2' }
 
       when {
-        allOf {
-          branch 'master'
-          expression {
-            boolean publish = false
+        expression {
+          def exitCode = sh returnStatus: true, script: ''' set +x
+            echo "Determining if publishing is requested..."
 
-            if(env.PUBLISH_GEM == "true") {
-              return true
-            }
+            VERSION=`cat lib/conjur/version.rb | grep \'VERSION\\s*=\' | sed -e "s/.*\'\\(.*\\)\'.*/\\1/"`
+            echo Declared version: $VERSION
 
-            try {
-              timeout(time: 5, unit: 'MINUTES') {
-                input(message: 'Publish to RubyGems?')
-                publish = true
-              }
-            } catch (final ignore) {
-              publish = false
-            }
+            # Jenkins git plugin is broken and always fetches with `--no-tags`
+            # (or `--tags`, neither of which is what you want), so tags end up
+            # not being fetched. Try to fix that.
+            # (Unfortunately this fetches all remote heads, so we may have to find
+            # another solution for bigger repos.)
+            git fetch -q
 
-            return publish
-          }
+            # note when tag not found git rev-parse will just print its name
+            TAG=`git rev-parse tags/v$VERSION 2>/dev/null || :`
+            echo Tag v$VERSION: $TAG
+
+            HEAD=`git rev-parse HEAD`
+            echo HEAD: $HEAD
+
+            test "$HEAD" = "$TAG"
+          '''
+          return exitCode == 0
         }
       }
       steps {


### PR DESCRIPTION
This change will make publishing as simple as ensuring there's a tag
on the commit corresponding to the declared version. Unfortunately
most of the time this will mean the job will have to be restarted
after pushing the tag. However at the price of this minor
inconvenience releasing is simplified and tied to git workflow.