### PR TITLE
Fix init certificate check when Conjur is routed behind SNI

### DIFF
--- a/lib/conjur/command/init.rb
+++ b/lib/conjur/command/init.rb
@@ -126,6 +126,7 @@ class Conjur::Command::Init < Conjur::Command
 
     sock = TCPSocket.new host, port.to_i
     ssock = SSLSocket.new sock
+    ssock.hostname = host
     ssock.connect
     chain = ssock.peer_cert_chain
     cert = chain.first


### PR DESCRIPTION
conjur init get wrong certificate when Conjur service is behind SNI.
The fix include hostname for sslsocket before connect.