### PR TITLE
Updates expectations in authenticate cuke

### DIFF
--- a/features/authentication/authenticate.feature
+++ b/features/authentication/authenticate.feature
@@ -2,7 +2,8 @@ Feature: Authenticate a role
 
   Scenario: Get a JSON token
     When I successfully run `conjur authn authenticate`
-    Then the JSON should have "data"
+    Then the JSON should have "protected"
+    And the JSON should have "payload"
     And the JSON should have "signature"
  
   Scenario: Get an auth token as HTTP Authorize header
@@ -16,7 +17,7 @@ Feature: Authenticate a role
     """
     And I login as "alice"
     When I successfully run `conjur authn authenticate`
-    Then the JSON at "data" should be "alice"
+    Then the JSON should be a hash
 
   @announce-command
   @announce-output


### PR DESCRIPTION
### What does this PR do?

It changes assumptions made in the authenticate cuke:
* instead of expecting "data" we expect "protected" and "payload"
* instead of looking for a specific value in data, we ask to see that the returned value is a JSON hash

### What is the context?

We changed how authn works, using a standard JWT instead of the custom JSON object we'd used before. Authentication still works but the tests were failing because of the assumptions they made.

### Link to build in Jenkins

https://jenkins.conjur.net/job/cyberark--conjur-cli/job/update-authn-cuke/ 