### PR TITLE
Installs policy plugin by default in Conjur CLI standalone v4 container

### DIFF
--- a/.conjurrc.default
+++ b/.conjurrc.default
@@ -1,0 +1,6 @@
+---
+account:
+plugins:
+- policy
+appliance_url:
+cert_file:

--- a/Dockerfile.standalone
+++ b/Dockerfile.standalone
@@ -22,12 +22,14 @@ RUN curl -sSL https://raw.githubusercontent.com/cyberark/summon/master/install.s
 #---install Conjur 4 CLI---#
 WORKDIR /src
 COPY . .
-COPY .conjurrc.default /root/.conjurrc
 ENV CONJURRC=/root/.conjurrc
 RUN gem build conjur-cli.gemspec && \
     gem install conjur-cli conjur-asset-policy && \
     cd /root && \
     rm -rf /src
+RUN mkdir -p /opt/conjur
+COPY ./.conjurrc.default /root/.conjurrc
+COPY ./.conjurrc.default /opt/conjur/.conjurrc.default
 
 #---set defaults---#
 WORKDIR /root

--- a/Dockerfile.standalone
+++ b/Dockerfile.standalone
@@ -22,8 +22,9 @@ RUN curl -sSL https://raw.githubusercontent.com/cyberark/summon/master/install.s
 #---install Conjur 4 CLI---#
 WORKDIR /src
 COPY . .
+ENV CONJURRC=/root/.conjurrc
 RUN gem build conjur-cli.gemspec && \
-    gem install conjur-cli && \
+    gem install conjur-cli conjur-asset-policy && \
     cd /root && \
     rm -rf /src
 

--- a/Dockerfile.standalone
+++ b/Dockerfile.standalone
@@ -22,6 +22,7 @@ RUN curl -sSL https://raw.githubusercontent.com/cyberark/summon/master/install.s
 #---install Conjur 4 CLI---#
 WORKDIR /src
 COPY . .
+COPY .conjurrc.default /root/.conjurrc
 ENV CONJURRC=/root/.conjurrc
 RUN gem build conjur-cli.gemspec && \
     gem install conjur-cli conjur-asset-policy && \

--- a/standalone.entrypoint
+++ b/standalone.entrypoint
@@ -3,7 +3,7 @@
 # If no conjurrc file is found, create one with the appropriate plugins entry
 
 if [ ! -f "$CONJURRC" ]; then
-    cp /src/.conjurrc.default "$CONJURRC"
+    cp /opt/conjur/.conjurrc.default "$CONJURRC"
 fi
 
 # A tool container entrypoint that tries to do the right thing whether you want

--- a/standalone.entrypoint
+++ b/standalone.entrypoint
@@ -1,5 +1,18 @@
 #!/bin/sh -e
 
+# If no conjurrc file is found, create one with the appropriate plugins entry
+
+if [ ! -f "$CONJURRC" ]; then
+    cat <<EOF >"$CONJURRC"
+---
+account:
+plugins:
+- policy
+appliance_url:
+cert_file:
+EOF
+fi
+
 # A tool container entrypoint that tries to do the right thing whether you want
 # an interactive shell environment or run a command directly.
 #

--- a/standalone.entrypoint
+++ b/standalone.entrypoint
@@ -3,14 +3,7 @@
 # If no conjurrc file is found, create one with the appropriate plugins entry
 
 if [ ! -f "$CONJURRC" ]; then
-    cat <<EOF >"$CONJURRC"
----
-account:
-plugins:
-- policy
-appliance_url:
-cert_file:
-EOF
+    cp /src/.conjurrc.default "$CONJURRC"
 fi
 
 # A tool container entrypoint that tries to do the right thing whether you want


### PR DESCRIPTION
#### What does this PR do?
* if no conjurrc is present (such as before `init`) it creates one with the plugin already specified
* installs the gems necessary for the policy plugin

#### What is the context?
People expect based on v5 behavior that v4 will be able to manage policies out of the box. This PR removes a stumbling block and saves the operator a little time and hassle.

#### How to manually test
You can verify that the plugin is installed like so:
```
./build-standalone
docker tag cyberark/conjur-cli cyberark/conjur-cli:4
docker run --rm -it cyberark/conjur-cli:4 help policy
```
Prior to this PR, the above would give you "command not found" but now it will print policy help.