### PR TITLE
Update Ruby versions in tests

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -11,16 +11,6 @@ pipeline {
   }
 
   stages {
-    stage('Test 2.3') {
-      environment {
-        RUBY_VERSION = '2.3'
-      }
-      steps {
-        sh './test.sh'
-        junit 'spec/reports/*.xml, features/reports/*.xml'
-      }
-    }
-
     stage('Test 2.4') {
       environment {
         RUBY_VERSION = '2.4'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -11,16 +11,6 @@ pipeline {
   }
 
   stages {
-    stage('Test 2.2') {
-      environment {
-        RUBY_VERSION = '2.2'
-      }
-      steps {
-        sh './test.sh'
-        junit 'spec/reports/*.xml, features/reports/*.xml'
-      }
-    }
-
     stage('Test 2.3') {
       environment {
         RUBY_VERSION = '2.3'
@@ -51,9 +41,9 @@ pipeline {
       }
     }
 
-    stage('Test 2.6 rc') {
+    stage('Test 2.6') {
       environment {
-        RUBY_VERSION = '2.6-rc'
+        RUBY_VERSION = '2.6'
       }
       steps {
         sh './test.sh'


### PR DESCRIPTION
Remove Ruby v2.2 EOL March 2018
Remove Ruby v2.3 EOL March 2019
Add Ruby 2.6 GA

