### PR TITLE
Update ruby 2.4 base image

### DIFF
--- a/Dockerfile.standalone
+++ b/Dockerfile.standalone
@@ -6,7 +6,7 @@
 #
 # Entrypoint is bash, with `conjur` command available.
 
-FROM ruby:2.4.1
+FROM ruby:2.4.6
 
 #---some useful tools for interactive usage---#
 RUN apt-get update && \

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,3 +1,5 @@
+#!/usr/bin/env groovy
+
 pipeline {
   agent { label 'executor-v2' }
 
@@ -41,12 +43,18 @@ pipeline {
       }
     }
 
-    stage('Build standalone image & push to DockerHub') {
+    stage('Build standalone image') {
+      steps {
+        sh './build-standalone'
+      }
+    }
+
+    stage('Push standalone image to DockerHub') {
       when {
         branch 'master'
       }
+
       steps {
-        sh './build-standalone'
         sh './push-image'
       }
     }
@@ -64,6 +72,7 @@ pipeline {
           return exitCode == 0
         }
       }
+
       steps {
         // Clean up first
         sh 'docker run -i --rm -v $PWD:/src -w /src alpine/git clean -fxd'

--- a/test.sh
+++ b/test.sh
@@ -6,6 +6,11 @@
 RUBY_VERSION=$(cut -d '-' -f 2 <<< $RUBY_VERSION)
 
 main() {
+
+  # set up the containers to run in their own namespace
+  COMPOSE_PROJECT_NAME="$(basename "$PWD")_$(openssl rand -hex 3)"
+  export COMPOSE_PROJECT_NAME
+
   build
 
   start_conjur


### PR DESCRIPTION
The base image used for the standalone CLI still depended on deprecated `jessie`, which broke the builds. This PR updates the base image and also builds the image in branches so that if a PR breaks the image build, the PR submitter will know it.