### PR TITLE
Add code coverage reporting to Code Climate

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -13,6 +13,15 @@ pipeline {
   }
 
   stages {
+    stage('Prepare For CodeClimate Coverage Report Submission'){
+      steps {
+        script {
+          ccCoverage.dockerPrep()
+          sh 'mkdir -p coverage'
+        }
+      }
+    }
+
     stage('Test 2.4') {
       environment {
         RUBY_VERSION = '2.4'
@@ -40,6 +49,14 @@ pipeline {
       steps {
         sh './test.sh'
         junit 'spec/reports/*.xml, features/reports/*.xml'
+      }
+    }
+
+    stage('Submit Coverage Report'){
+      steps{
+        sh 'ci/submit-coverage'
+        archiveArtifacts artifacts: "coverage/.resultset.json", fingerprint: false
+        publishHTML([reportDir: 'coverage', reportFiles: 'index.html', reportName: 'Coverage Report', reportTitles: '', allowMissing: false, alwaysLinkToLastBuild: true, keepAll: true])
       }
     }
 

--- a/ci/submit-coverage
+++ b/ci/submit-coverage
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+set -eux
+
+DIR="coverage"
+BIN="cc-test-reporter"
+REPORT="${DIR}/.resultset.json"
+
+if [[ ! -e ${REPORT} ]]; then
+    echo "SimpleCov report (${REPORT}) not found"
+    ls -laR ${DIR}
+    exit 1
+fi
+
+if [[ ! -x ${BIN} ]]; then
+    echo "cc-test-reporter binary not found, not reporting coverage data to code climate"
+    ls -laR ${DIR}
+    # report is present but reporter binary is not, definitely a bug, exit error.
+    exit 1
+fi
+
+# Simplecov excludes files not within the current repo, it also needs to
+# be able to read all the files referenced within the report. As the reports
+# are generated in containers, the absolute paths contained in the report
+# are not valid outside that container. This sed fixes the paths
+# So they are correct relative to the Jenkins workspace.
+sed -i -E "s+/src+${WORKSPACE}+g" "${REPORT}"
+
+echo "Coverage reports prepared, submitting to CodeClimate."
+# vars GIT_COMMIT, GIT_BRANCH & TRID are set by ccCoverage.dockerPrep
+
+./${BIN} after-build \
+    --coverage-input-type "simplecov"\
+    --id "${TRID}"
+
+echo "Successfully Reported Coverage Data"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,6 +25,7 @@ services:
       - CONJUR_ACCOUNT=cucumber
       - CONJUR_AUTHN_LOGIN=admin
       - CONJUR_AUTHN_API_KEY
+      - RUBY_VERSION=${RUBY_VERSION}
     volumes:
       - .:/src
 

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -6,7 +6,9 @@ require 'aruba/cucumber'
 require 'json_spec/cucumber'
 require 'simplecov'
 
-SimpleCov.start
+SimpleCov.start do
+  command_name "#{ENV['RUBY_VERSION']}"
+end
 
 ENV['CONJUR_APPLIANCE_URL'] ||= 'http://localhost/api/v6'
 ENV['CONJUR_ACCOUNT'] ||= 'cucumber'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,8 +4,11 @@ require 'tempfile'
 require 'ostruct'
 
 require "simplecov"
-SimpleCov.start
-  
+
+SimpleCov.start do
+  command_name "#{ENV['RUBY_VERSION']}"
+end
+
 def post_response(id, attributes = {})
   attributes[:id] = id
   


### PR DESCRIPTION
Code coverage reporting to Code Climate can only be done once, so the
command_name needs to be set for each Ruby version tested against.