### PR TITLE
Add jq to install list

### DIFF
--- a/Dockerfile.standalone
+++ b/Dockerfile.standalone
@@ -16,6 +16,7 @@ RUN apt-get update && \
       build-essential \
       curl \
       git \
+      jq \
       nano \
       openssh-client \
       ruby2.5 ruby2.5-dev \


### PR DESCRIPTION
Add jq to list of installs. Fixes tests like https://github.com/cyberark/conjur-puppet/issues/50 failing from not having jq.