### PR TITLE
Remove parse-changelog.sh from Gem executables

### DIFF
--- a/conjur-cli.gemspec
+++ b/conjur-cli.gemspec
@@ -18,6 +18,9 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   gem.version       = Conjur::VERSION
 
+  # Filter out development only executables
+  gem.executables -= %w{parse-changelog.sh}
+
   gem.add_dependency 'activesupport', '>= 4.2', '< 6'
   gem.add_dependency 'conjur-api', '~> 5.3'
   gem.add_dependency 'deep_merge', '~> 1.0'


### PR DESCRIPTION
This PR removes `parse-changelog.sh` from the Gemspec executables.

Connected to #261 

`parse-changelog.sh` is a development dependency of the CLI, and when other Gems also include this script, it causes an error when installed together.

For example, installing both `conjur-api` and `conjur-cli` leads to:
```
$ gem install ./conjur-cli-6.2.1.gem
conjur-cli's executable "parse-changelog.sh" conflicts with conjur-api
```