### PR TITLE
Update rake for CVE-2020-8130

### DIFF
--- a/conjur-cli.gemspec
+++ b/conjur-cli.gemspec
@@ -37,7 +37,7 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency 'io-grab', '~> 0.0'
   gem.add_development_dependency 'json_spec'
   gem.add_development_dependency 'pry-byebug'
-  gem.add_development_dependency 'rake', '~> 10.0'
+  gem.add_development_dependency 'rake', '~> 12.3.3'
   gem.add_development_dependency 'rspec', '~> 3.0'
   gem.add_development_dependency 'simplecov', '~> 0.17', '< 0.18'
 end


### PR DESCRIPTION
For details see: https://nvd.nist.gov/vuln/detail/CVE-2020-8130