### PR TITLE
Update check for whether to publish Dockerhub image

### DIFF
--- a/push-image
+++ b/push-image
@@ -22,7 +22,7 @@ git_description=$(git describe)
 # only when tag matches the VERSION, push VERSION and latest releases
 # and x and x.y releases
 #Ex: v5-6.2.1
-if [ "$git_description" = "v${VERSION_TAG}" ]; then
+if [ "$git_description" = "v${VERSION}" ]; then
   echo "Revision $git_description matches version $VERSION exactly. Pushing to Dockerhub..."
 
   for tag in "${TAGS[@]}"; do


### PR DESCRIPTION
It was comparing the git tag to `5-${VERSION}` instead of just to `${VERSION}`, so the Docker image did not publish.