### PR TITLE
Fixable and total trivy issues

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -97,7 +97,7 @@ pipeline {
       parallel {
         stage('Scan Docker image for fixable vulns') {
           steps {
-            scanAndReport("cyberark/conjur-cli:latest", "NONE", false)
+            scanAndReport("cyberark/conjur-cli:latest", "HIGH", false)
           }
         }
         stage('Scan Docker image for total vulns') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -94,8 +94,17 @@ pipeline {
     }
 
     stage('Scan Docker image') {
-      steps {
-        scanAndReport("cyberark/conjur-cli:latest", "NONE")
+      parallel {
+        stage('Scan Docker image for fixable vulns') {
+          steps {
+            scanAndReport("cyberark/conjur-cli:latest", "NONE", false)
+          }
+        }
+        stage('Scan Docker image for total vulns') {
+          steps {
+            scanAndReport("cyberark/conjur-cli:latest", "NONE", true)
+          }
+        }
       }
     }
 


### PR DESCRIPTION
Adds an additional trivy scan (in parallel with the first) for a total of 2. One lists only fixable potential vulnerabilities. The other lists all potential vulnerabilities detected (including ones for which no fix is available). Only the presence of potential HIGH or CRITICAL vulnerabilities with fixes will cause build failures. 

Signed-off-by: Andy Tinkham <andy.tinkham@cyberark.com>