### PR TITLE
Push conjur-cli to internal registry

### DIFF
--- a/push-image
+++ b/push-image
@@ -3,6 +3,7 @@
 set -e
 
 readonly REGISTRY="cyberark"
+readonly INTERNAL_REGISTRY="registry2.itci.conjur.net"
 readonly VERSION="$(cat VERSION)"
 readonly VERSION_TAG="5-${VERSION}"
 readonly image_name="conjur-cli"
@@ -22,17 +23,24 @@ git_description=$(git describe)
 # only when tag matches the VERSION, push VERSION and latest releases
 # and x and x.y releases
 #Ex: v5-6.2.1
-if [ "$git_description" = "v${VERSION}" ]; then
-  echo "Revision $git_description matches version $VERSION exactly. Pushing to Dockerhub..."
+if [ "${git_description}" = "v${VERSION}" ]; then
+  echo "Revision ${git_description} matches version ${VERSION} exactly. Pushing to Dockerhub..."
 
   for tag in "${TAGS[@]}"; do
-    echo "Tagging and pushing $REGISTRY/$image_name:$tag"
+    echo "Tagging and pushing ${REGISTRY}/${image_name}:${tag}"
 
-    docker tag $full_image_name "$REGISTRY/$image_name:$tag"
-    docker push "$REGISTRY/$image_name:$tag"
+    # push to dockerhub
+    docker tag "${full_image_name}" "${REGISTRY}/${image_name}:${tag}"
+    docker push "${REGISTRY}/${image_name}:${tag}"
+
+    # push to internal registry
+    # necessary because some cyberark teams/networks can't pull from dockerhub
+    docker tag "${full_image_name}" "${INTERNAL_REGISTRY}/${image_name}:${tag}"
+    docker push "${INTERNAL_REGISTRY}/${image_name}:${tag}"
+
   done
 
   # push to legacy `conjurinc/cli5` tag
-  docker tag $full_image_name conjurinc/cli5:latest
+  docker tag "${full_image_name}" conjurinc/cli5:latest
   docker push conjurinc/cli5:latest
 fi


### PR DESCRIPTION
Currently conjur-cli images are pushed to public dockerhub, some
cyberark teams/networks have restrictions on pulling from public
dockerhub, but can fetch images from the internal registry. To enable
them to make use of the conjur-cli docker image we push to both
registries.

### What does this PR do?
Push releases to internal registry in addition to the existing push to docker hub.
The reason for this change is to enable Cyberark teams without access to dockerhub to use conjur-cli. 

### What ticket does this PR close?
Connected to conjurinc/ops#675
### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation