### PR TITLE
Fixed build by updating variables required for conjur-api v5.3.4

### DIFF
--- a/lib/conjur/command/rspec/mock_services.rb
+++ b/lib/conjur/command/rspec/mock_services.rb
@@ -29,7 +29,13 @@ end
 shared_context "when logged in", logged_in: true do
   include_context "with mock authn"
   before do
-    allow(api).to receive(:credentials) { {} }
+    allow(api).to receive(:credentials) do
+      {
+        :username => 'dknuth',
+        :headers => { :authorization => "fakeauth" },
+      }
+    end
+
     netrc[authn_host] = [username, api_key]
     allow(Conjur::Command).to receive_messages api: api
   end

--- a/spec/command/hosts_spec.rb
+++ b/spec/command/hosts_spec.rb
@@ -9,13 +9,19 @@ describe Conjur::Command::Hosts, logged_in: true do
         expect(RestClient::Request).to receive(:execute).with({
           method: :head,
           url: "https://core.example.com/api/resources/#{account}/host/redis001",
-          headers: {}
+          headers: {
+            authorization: "fakeauth",
+          },
+          username: "dknuth",
         }).and_return true
         expect(RestClient::Request).to receive(:execute).with({
             method: :put,
             url: "https://core.example.com/api/authn/#{account}/api_key?role=#{account}:host:redis001",
-            headers: {},
-            payload: ''
+            headers: {
+              authorization: "fakeauth",
+            },
+            payload: '',
+            username: "dknuth",
         }).and_return double(:response, body: 'new api key')
       end
 


### PR DESCRIPTION
Since the new `conjur-api` gem requires the api to have a valid
`credentials` field which the tests were mocking partially. We now do a
bit more mocking out to have the proper structure that the API can
consume in the rspec tests.

### What ticket does this PR close?
Resolves #299 

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [x] This PR includes new unit and integration tests to go with the code changes, or
- [ ] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation