### PR TITLE
Handle rotate API key for non existing user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- The Conjur CLI now raises a proper error when trying to rotate a non-existing user's API key
+  ([cyberark/conjur#979](https://github.com/cyberark/conjur/issues/979))
 
 ## [6.2.2] - 2020-04-02
 ### Changed

--- a/lib/conjur/command/hosts.rb
+++ b/lib/conjur/command/hosts.rb
@@ -36,7 +36,7 @@ class Conjur::Command::Hosts < Conjur::Command
           host_resourceid = full_resource_id("host:#{host}")
 
           unless api.resource(host_resourceid).exists?
-            exit_now! "host '#{host}' not found"
+            exit_now! "Host '#{host}' not found"
           end
 
           # Prepend 'host/' if it wasn't passed in

--- a/lib/conjur/command/users.rb
+++ b/lib/conjur/command/users.rb
@@ -47,7 +47,11 @@ class Conjur::Command::Users < Conjur::Command
           if api.username == options[:user]
             exit_now! 'To rotate the API key of the currently logged-in user, use this command without any flags or options'
           end
-          puts api.resource([ Conjur.configuration.account, "user", options[:user] ].join(":")).rotate_api_key
+          user_resource_id = [Conjur.configuration.account, "user", options[:user]].join(":")
+          unless api.resource(user_resource_id).exists?
+            exit_now! "User '#{options[:user]}' not found"
+          end
+          puts api.resource(user_resource_id).rotate_api_key
         else
           username, password = Conjur::Authn.read_credentials
           new_api_key = Conjur::API.rotate_api_key username, password

--- a/spec/command/hosts_spec.rb
+++ b/spec/command/hosts_spec.rb
@@ -29,5 +29,19 @@ describe Conjur::Command::Hosts, logged_in: true do
         invoke
       end
     end
+
+    describe_command 'host rotate_api_key --host non-existing' do
+      before do
+        expect(RestClient::Request).to receive(:execute).with({
+                  method: :head,
+                  url: "https://core.example.com/api/resources/#{account}/host/non-existing",
+                  headers: {authorization: "fakeauth"},
+                  username: username,
+              }).and_raise RestClient::ResourceNotFound
+      end
+      it 'rotate_api_key with non-existing --host option' do
+        expect { invoke }.to raise_error(GLI::CustomExit, /Host 'non-existing' not found/i)
+      end
+    end
   end
 end

--- a/spec/command/users_spec.rb
+++ b/spec/command/users_spec.rb
@@ -52,5 +52,18 @@ describe Conjur::Command::Users, logged_in: true do
         invoke
       end
     end
+    describe_command 'user rotate_api_key --user non-existing' do
+      before do
+      expect(RestClient::Request).to receive(:execute).with({
+            method: :head,
+            url: "https://core.example.com/api/resources/#{account}/user/non-existing",
+            headers: {authorization: "fakeauth"},
+            username: username,
+        }).and_raise RestClient::ResourceNotFound
+      end
+      it 'rotate_api_key with non-existing --user option' do
+        expect { invoke }.to raise_error(GLI::CustomExit, /User 'non-existing' not found/i)
+      end
+    end
   end
 end


### PR DESCRIPTION
### What does this PR do?
Handle rotate API key for non existing user
- _What's changed? Why were these changes made?_
Before sending request to rotate key we verify that the user actually exists, similarly to what happens for rotating API keys for hosts.
- _How should the reviewer approach this PR, especially if manual tests are required?_
No, there is an integration test 
- _Are there relevant screenshots you can add to the PR description?_
User input:
![image](https://user-images.githubusercontent.com/73833665/100075190-509e3280-2e48-11eb-8898-a9bb75ad10be.png)
Output:
![image](https://user-images.githubusercontent.com/73833665/100075251-657ac600-2e48-11eb-9aa4-0dbfce8bab1f.png)

### What ticket does this PR close?
Resolves [#979](https://github.com/cyberark/conjur/issues/979)

### Checklists

#### Change log
- [x] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [x] This PR includes new unit and integration tests to go with the code changes, or
- [ ] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [ ] This PR does not require updating any documentation