### PR TITLE
Account for custom Ruby API rest_client_options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Conjur CLI internally uses `rest_client_options` new to `conjur-api` 5.3.5.
+  [cyberark/conjur-cli#310](https://github.com/cyberark/conjur-cli/issues/310)
 
 ## [6.2.3] - 2020-12-22
 ### Fixed

--- a/lib/conjur/command/rspec/describe_command.rb
+++ b/lib/conjur/command/rspec/describe_command.rb
@@ -5,15 +5,34 @@ RSpec::Core::DSL.change_global_dsl do
         
       before do
         allow(cert_store).to receive(:add_file)
+        # Stub the constant OpenSSL::SSL::SSLContext::DEFAULT_CERT_STORE which is
+        # implicitly used in many places in the CLI and in conjur-api-ruby as the de facto
+        # cert store.
         stub_const 'OpenSSL::SSL::SSLContext::DEFAULT_CERT_STORE', cert_store
+
+        # Reset the rest_client_options defaults to avoid using expired rspec doubles.
+        #
+        # Conjur.configuration is a lazy-loaded singleton. There is single CLI instance
+        # shared across this test suite. When Conjur.configuration is loaded for the first
+        # time it assumes the defaults value for Conjur.configuration.rest_client_options
+        # of:
+        # {
+        #  :ssl_cert_store => OpenSSL::SSL::SSLContext::DEFAULT_CERT_STORE
+        # }
+        #
+        # Notice above that each test case stubs the constant
+        # OpenSSL::SSL::SSLContext::DEFAULT_CERT_STORE with a double. Without further
+        # modification this means the first time the CLI is run and Conjur.configuration
+        # is loaded Conjur.configuration.rest_client_options[:ssl_cert_store] it is set to
+        # the double associated with the test case at that point in time. Since
+        # Conjur.configuration is only loaded once, without modification, that double will
+        # be retained and its usage will result in a RSpec::Mocks::ExpiredTestDoubleError.
+        # To avoid this for each test case we must reset
+        # Conjur.configuration.rest_client_options[:ssl_cert_store] with the double for
+        # the current test case.
+        Conjur.configuration.rest_client_options[:ssl_cert_store] = cert_store
       end
-      
-      let(:cert_store_options) do
-        {
-          ssl_cert_store: cert_store
-        }
-      end
-      
+
       let(:invoke) do
         Conjur::CLI.error_device = $stderr
         # TODO: allow proper handling of description like "audit:send 'hello world'"

--- a/spec/command/hosts_spec.rb
+++ b/spec/command/hosts_spec.rb
@@ -13,6 +13,7 @@ describe Conjur::Command::Hosts, logged_in: true do
             authorization: "fakeauth",
           },
           username: "dknuth",
+          ssl_cert_store: cert_store
         }).and_return true
         expect(RestClient::Request).to receive(:execute).with({
             method: :put,
@@ -22,6 +23,7 @@ describe Conjur::Command::Hosts, logged_in: true do
             },
             payload: '',
             username: "dknuth",
+            ssl_cert_store: cert_store
         }).and_return double(:response, body: 'new api key')
       end
 
@@ -37,6 +39,7 @@ describe Conjur::Command::Hosts, logged_in: true do
                   url: "https://core.example.com/api/resources/#{account}/host/non-existing",
                   headers: {authorization: "fakeauth"},
                   username: username,
+                  ssl_cert_store: cert_store
               }).and_raise RestClient::ResourceNotFound
       end
       it 'rotate_api_key with non-existing --host option' do

--- a/spec/command/users_spec.rb
+++ b/spec/command/users_spec.rb
@@ -12,7 +12,8 @@ describe Conjur::Command::Users, logged_in: true do
         user: username, 
         password: api_key,
         headers: { },
-        payload: "new-password"
+        payload: "new-password",
+        ssl_cert_store: cert_store
        })
     end
     
@@ -40,7 +41,8 @@ describe Conjur::Command::Users, logged_in: true do
                     user: username,
                     password: api_key,
                     headers: {},
-                    payload: ''
+                    payload: '',
+                    ssl_cert_store: cert_store
                 }).and_return double(:response, body: 'new api key')
         expect(Conjur::Authn).to receive(:save_credentials).with({
                     username: username,
@@ -59,6 +61,7 @@ describe Conjur::Command::Users, logged_in: true do
             url: "https://core.example.com/api/resources/#{account}/user/non-existing",
             headers: {authorization: "fakeauth"},
             username: username,
+            ssl_cert_store: cert_store
         }).and_raise RestClient::ResourceNotFound
       end
       it 'rotate_api_key with non-existing --user option' do


### PR DESCRIPTION
### What does this PR do?
CLI previously used a global cert store. Ruby API
recently added custom rest_client_options, allowing
configurable RestClient::Requests. CLI now accounts
for this by setting custom cert store instead of
global.

### What ticket does this PR close?
Resolves #310 

### Checklists

#### Change log
- [x] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation