### PR TITLE
Updating naming for Conjur editions

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ A complete reference guide is available at [conjur.org](https://www.conjur.org).
 ## Table of Contents
 - [Getting Started](#getting-started)
     - [Quick Start](#quick-start)
-    - [Using This Project With Conjur OSS](#Using-conjur-cli-with-Conjur-OSS)
+    - [Using This Project With Conjur Open Source](#Using-conjur-cli-with-Conjur-Open-Source)
 - [Using Docker](#using-docker)
 - [Usage](#usage)
 - [Contributing](#contributing)
@@ -26,9 +26,9 @@ $ conjur -v
 conjur version 6.0.0
 ```
 
-### Using conjur-cli with Conjur OSS 
+### Using conjur-cli with Conjur Open Source 
 
-Are you using this project with [Conjur OSS](https://github.com/cyberark/conjur)? Then we 
+Are you using this project with [Conjur Open Source](https://github.com/cyberark/conjur)? Then we 
 **strongly** recommend choosing the version of this project to use from the latest [Conjur OSS 
 suite release](https://docs.conjur.org/Latest/en/Content/Overview/Conjur-OSS-Suite-Overview.html). 
 Conjur maintainers perform additional testing on the suite release versions to ensure 


### PR DESCRIPTION
Updating naming for Conjur editions

- converts `Conjur OSS` to `Conjur Open Source`
- converts `DAP`/`Dynamic Access Provider` to `Conjur Enterprise`
- maintains `Conjur OSS Suite` and `Conjur Open Source Suite`

This is part of an automated batch of PRs across many repos listed in [cyberark/community#92](https://github.com/cyberark/community/issues/92)
