### PR TITLE
ONYX-14249: Allow activesupport 6 as a dependency

### DIFF
--- a/conjur-cli.gemspec
+++ b/conjur-cli.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |gem|
   # Filter out development only executables
   gem.executables -= %w{parse-changelog.sh}
 
-  gem.add_dependency 'activesupport', '>= 4.2', '< 6'
+  gem.add_dependency 'activesupport', '>= 4.2'
   gem.add_dependency 'conjur-api', '~> 5.3'
   gem.add_dependency 'deep_merge', '~> 1.0'
   gem.add_dependency 'gli', '>=2.8.0'


### PR DESCRIPTION
### Desired Outcome

`activesupport` gem V6.X.X is a possible dependency of conjur-cli. (before that was limited to Ver<=5.0)

### Implemented Changes

Change dependency in conjur-cli.gemspec

The end goal is to support rails 6.X.X gem in other conjur related repositories.
`activesupport` 6.X.X is a dependency to Rails 6.X.X.

### Connected Issue/Story

CyberArk internal issue link: [ONYX-14249](https://ca-il-jira.il.cyber-ark.com:8443/browse/ONYX-14249)

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [x] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]()
- [x] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [x] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [x] There are no security aspects to these changes 
