### PR TITLE
Update activesupport to V7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [6.2.7] - 2022-02-13
+
+### Changed
+- Bump activesupport to V7.
+
 ## [6.2.6] - 2022-01-31
 
 ### Changed

--- a/conjur-cli.gemspec
+++ b/conjur-cli.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |gem|
   # Filter out development only executables
   gem.executables -= %w{parse-changelog.sh}
 
-  gem.add_dependency 'activesupport', '~> 6.0'
+  gem.add_dependency 'activesupport', '~> 7.0'
   gem.add_dependency 'conjur-api', '~> 5.3'
   gem.add_dependency 'deep_merge', '~> 1.0'
   gem.add_dependency 'gli', '>=2.8.0'


### PR DESCRIPTION
### Desired Outcome

`activesupport` is updated to V7.
Trigger for update is updating `Rails to V7` in conjur-oss, to address HIGH security vulnerability [CVE-2022-23633](https://nvd.nist.gov/vuln/detail/CVE-2022-23633).

### Implemented Changes

Updated [gemspec](url) file.

### Connected Issue/Story

CyberArk internal issue link: [insert issue ID]()

### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- [x] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [x] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]()
- [x] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [x] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [ ] There are no security aspects to these changes 
