### PR TITLE
CONJSE-1802: Changes to publish.sh for ruby CVE-2023-5129

### DIFF
--- a/publish.sh
+++ b/publish.sh
@@ -1,8 +1,8 @@
 #!/bin/bash -e
 
-# conjurinc/publish-rubygem -> conjurinc/release-tools
-docker pull registry.tld/conjurinc/release-tools
+# conjurinc/publish-rubygem -> conjurinc/release-tools/bin/publish-rubygem
+docker pull registry.tld/conjurinc/release-tools/bin/publish-rubygem
 
 summon --yaml "RUBYGEMS_API_KEY: !var rubygems/api-key" \
   docker run --rm --env-file @SUMMONENVFILE -v "$(pwd)":/opt/src \
-  registry.tld/conjurinc/release-tools conjur-cli
+  registry.tld/conjurinc/release-tools/bin/publish-rubygem conjur-cli

--- a/publish.sh
+++ b/publish.sh
@@ -1,8 +1,10 @@
 #!/bin/bash -e
 
 # conjurinc/publish-rubygem -> conjurinc/release-tools/bin/publish-rubygem
-docker pull registry.tld/conjurinc/release-tools/bin/publish-rubygem
+#docker pull registry.tld/conjurinc/release-tools/bin/publish-rubygem
 
 summon --yaml "RUBYGEMS_API_KEY: !var rubygems/api-key" \
   docker run --rm --env-file @SUMMONENVFILE -v "$(pwd)":/opt/src \
-  registry.tld/conjurinc/release-tools/bin/publish-rubygem conjur-cli
+  registry.tld/conjurinc/release-tools/bin/publish-rubygem-container-entrpoint.sh conjur-cli
+
+#publish-rubygem-container-entrpoint.sh

--- a/publish.sh
+++ b/publish.sh
@@ -1,10 +1,56 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
+# ! /bin/bash -e
 
 # conjurinc/publish-rubygem -> conjurinc/release-tools/bin/publish-rubygem
 #docker pull registry.tld/conjurinc/release-tools/bin/publish-rubygem
 
-summon --yaml "RUBYGEMS_API_KEY: !var rubygems/api-key" \
-  docker run --rm --env-file @SUMMONENVFILE -v "$(pwd)":/opt/src \
-  registry.tld/conjurinc/release-tools/bin/publish-rubygem-container-entrpoint.sh conjur-cli
+#summon --yaml "RUBYGEMS_API_KEY: !var rubygems/api-key" \
+#  docker run --rm --env-file @SUMMONENVFILE -v "$(pwd)":/opt/src \
+#  registry.tld/conjurinc/release-tools/bin/publish-rubygem-container-entrpoint.sh conjur-cli
 
 #publish-rubygem-container-entrpoint.sh
+
+#!/usr/bin/env bash
+set -e
+
+if [ $# -ne 1 ]; then
+  echo "Usage: $0 <project>"
+  exit 1
+fi
+
+project="${1}"
+
+if [ ! -f "${project}.gemspec" ]; then
+  echo "Cannot find ${project}.gemspec"
+  echo "Usage: $0 <project>"
+  exit 1
+fi
+
+echo "Updating package list..."
+apt-get update > /dev/null 2>&1
+echo "Installing dependencies..."
+apt-get install -y git > /dev/null 2>&1
+
+git config --global --add safe.directory "$(pwd)"
+
+echo "Building gem..."
+
+gem build "${project}.gemspec"
+
+echo "Publishing gem..."
+# write API key to credentials file
+mkdir -p /root/.gem
+cat > /root/.gem/credentials <<EOF
+---
+:rubygems_api_key: $RUBYGEMS_API_KEY
+EOF
+chmod 0600 /root/.gem/credentials
+
+spec_name=$(grep spec.name "${project}.gemspec" | awk -F"=" '{print $2}' | xargs)
+
+# Some gems use gem rather than spec
+if [ -z "${spec_name}" ]; then
+  spec_name=$(grep gem.name "${project}.gemspec" | awk -F"=" '{print $2}' | xargs)
+fi
+
+gem push "${spec_name}"-*.gem

--- a/publish.sh
+++ b/publish.sh
@@ -1,16 +1,4 @@
 #!/usr/bin/env bash
-# ! /bin/bash -e
-
-# conjurinc/publish-rubygem -> conjurinc/release-tools/bin/publish-rubygem
-#docker pull registry.tld/conjurinc/release-tools/bin/publish-rubygem
-
-#summon --yaml "RUBYGEMS_API_KEY: !var rubygems/api-key" \
-#  docker run --rm --env-file @SUMMONENVFILE -v "$(pwd)":/opt/src \
-#  registry.tld/conjurinc/release-tools/bin/publish-rubygem-container-entrpoint.sh conjur-cli
-
-#publish-rubygem-container-entrpoint.sh
-
-#!/usr/bin/env bash
 set -e
 
 if [ $# -ne 1 ]; then
@@ -26,31 +14,83 @@ if [ ! -f "${project}.gemspec" ]; then
   exit 1
 fi
 
-echo "Updating package list..."
-apt-get update > /dev/null 2>&1
-echo "Installing dependencies..."
-apt-get install -y git > /dev/null 2>&1
+base="$(dirname "${0}")"
 
-git config --global --add safe.directory "$(pwd)"
+docker run \
+  --rm \
+  --env RUBYGEMS_API_KEY \
+  --volume "$(pwd)":"$(pwd)" \
+  --workdir "$(pwd)" \
+  cyberark/ubuntu-ruby-builder:latest \
+  "${base}/publish-rubygem-container-entrpoint.sh" "${project}"
 
-echo "Building gem..."
 
-gem build "${project}.gemspec"
 
-echo "Publishing gem..."
-# write API key to credentials file
-mkdir -p /root/.gem
-cat > /root/.gem/credentials <<EOF
----
-:rubygems_api_key: $RUBYGEMS_API_KEY
-EOF
-chmod 0600 /root/.gem/credentials
 
-spec_name=$(grep spec.name "${project}.gemspec" | awk -F"=" '{print $2}' | xargs)
+# ! /bin/bash -e
 
-# Some gems use gem rather than spec
-if [ -z "${spec_name}" ]; then
-  spec_name=$(grep gem.name "${project}.gemspec" | awk -F"=" '{print $2}' | xargs)
-fi
+#docker pull registry.tld/conjurinc/publish-rubygem
+#
+#summon --yaml "RUBYGEMS_API_KEY: !var rubygems/api-key" \
+#  docker run --rm --env-file @SUMMONENVFILE -v "$(pwd)":/opt/src \
+#  registry.tld/conjurinc/publish-rubygem conjur-cli
 
-gem push "${spec_name}"-*.gem
+
+
+# conjurinc/publish-rubygem -> conjurinc/release-tools/bin/publish-rubygem
+#docker pull registry.tld/conjurinc/release-tools/bin/publish-rubygem
+
+#summon --yaml "RUBYGEMS_API_KEY: !var rubygems/api-key" \
+#  docker run --rm --env-file @SUMMONENVFILE -v "$(pwd)":/opt/src \
+#  registry.tld/conjurinc/release-tools/bin/publish-rubygem-container-entrpoint.sh conjur-cli
+
+#publish-rubygem-container-entrpoint.sh
+
+
+
+
+
+##!/usr/bin/env bash
+#set -e
+#
+#if [ $# -ne 1 ]; then
+#  echo "Usage: $0 <project>"
+#  exit 1
+#fi
+#
+#project="${1}"
+#
+#if [ ! -f "${project}.gemspec" ]; then
+#  echo "Cannot find ${project}.gemspec"
+#  echo "Usage: $0 <project>"
+#  exit 1
+#fi
+#
+#echo "Updating package list..."
+#apt-get update > /dev/null 2>&1
+#echo "Installing dependencies..."
+#apt-get install -y git > /dev/null 2>&1
+#
+#git config --global --add safe.directory "$(pwd)"
+#
+#echo "Building gem..."
+#
+#gem build "${project}.gemspec"
+#
+#echo "Publishing gem..."
+## write API key to credentials file
+#mkdir -p /root/.gem
+#cat > /root/.gem/credentials <<EOF
+#---
+#:rubygems_api_key: $RUBYGEMS_API_KEY
+#EOF
+#chmod 0600 /root/.gem/credentials
+#
+#spec_name=$(grep spec.name "${project}.gemspec" | awk -F"=" '{print $2}' | xargs)
+#
+## Some gems use gem rather than spec
+#if [ -z "${spec_name}" ]; then
+#  spec_name=$(grep gem.name "${project}.gemspec" | awk -F"=" '{print $2}' | xargs)
+#fi
+#
+#gem push "${spec_name}"-*.gem

--- a/publish.sh
+++ b/publish.sh
@@ -1,7 +1,8 @@
 #!/bin/bash -e
 
-docker pull registry.tld/conjurinc/publish-rubygem
+# conjurinc/publish-rubygem -> conjurinc/release-tools
+docker pull registry.tld/conjurinc/release-tools
 
 summon --yaml "RUBYGEMS_API_KEY: !var rubygems/api-key" \
   docker run --rm --env-file @SUMMONENVFILE -v "$(pwd)":/opt/src \
-  registry.tld/conjurinc/publish-rubygem conjur-cli
+  registry.tld/conjurinc/release-tools conjur-cli

--- a/publish.sh
+++ b/publish.sh
@@ -1,39 +1,41 @@
-#!/usr/bin/env bash
-set -e
-
-if [ $# -ne 1 ]; then
-  echo "Usage: $0 <project>"
-  exit 1
-fi
-
-project="${1}"
-
-if [ ! -f "${project}.gemspec" ]; then
-  echo "Cannot find ${project}.gemspec"
-  echo "Usage: $0 <project>"
-  exit 1
-fi
-
-base="$(dirname "${0}")"
-
-docker run \
-  --rm \
-  --env RUBYGEMS_API_KEY \
-  --volume "$(pwd)":"$(pwd)" \
-  --workdir "$(pwd)" \
-  cyberark/ubuntu-ruby-builder:latest \
-  "${base}/publish-rubygem-container-entrpoint.sh" "${project}"
-
-
-
-
-# ! /bin/bash -e
-
-#docker pull registry.tld/conjurinc/publish-rubygem
+# ! /usr/bin/env bash
+#set -e
 #
-#summon --yaml "RUBYGEMS_API_KEY: !var rubygems/api-key" \
-#  docker run --rm --env-file @SUMMONENVFILE -v "$(pwd)":/opt/src \
-#  registry.tld/conjurinc/publish-rubygem conjur-cli
+#if [ $# -ne 1 ]; then
+#  echo "Usage: $0 <project>"
+#  exit 1
+#fi
+#
+#project="${1}"
+#
+#if [ ! -f "${project}.gemspec" ]; then
+#  echo "Cannot find ${project}.gemspec"
+#  echo "Usage: $0 <project>"
+#  exit 1
+#fi
+#
+#base="$(dirname "${0}")"
+#
+#docker run \
+#  --rm \
+#  --env RUBYGEMS_API_KEY \
+#  --volume "$(pwd)":"$(pwd)" \
+#  --workdir "$(pwd)" \
+#  cyberark/ubuntu-ruby-builder:latest \
+#  "${base}/publish-rubygem-container-entrpoint.sh" "${project}"
+
+
+
+#Original
+#!/bin/bash -e
+
+docker pull registry.tld/conjurinc/publish-rubygem
+
+summon --yaml "RUBYGEMS_API_KEY: !var rubygems/api-key" \
+  docker run --rm --env-file @SUMMONENVFILE -v "$(pwd)":/opt/src \
+  registry.tld/conjurinc/publish-rubygem conjur-cli
+
+
 
 
 


### PR DESCRIPTION
6 repos still use the container built in the conjurinc/publish_rubygem repo. This container uses Ruby 2.7 as its base image which contains a version of libwebp that is vulnerable to CVE-2023-5129. We are not vulnerable to this CVE, but need to use software that includes a fixed version.

Rather than upgrading publish_rubygem to Ruby 3, we should instead convert the remaining repositories that still use the container over to use the release-tools version, and then archive the conjurinc/publish_rubygem repo entirely.